### PR TITLE
Updated .help, .pickreactor, .poll. added commandNames

### DIFF
--- a/src/@types/discord.d.ts
+++ b/src/@types/discord.d.ts
@@ -4,5 +4,6 @@ import { Command } from './bot';
 declare module 'discord.js' {
   interface Client {
     commands: Discord.Collection<string, Command>;
+    commandNames: string[];
   }
 }

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -7,13 +7,14 @@ export default {
   category: ['Help'],
   usage: ['<command name - optional>'],
   async execute(message: Discord.Message, args: string[]): Promise<void> {
-    const { commands } = message.client;
+    const { commands, commandNames } = message.client;
     const em = new Discord.RichEmbed();
 
     em.setColor(0x59afef);
 
     if (!args.length) {
-      em.addField('command list:', commands.map((command): string => command.name).join('\n'), true);
+      // em.addField('command list:', commands.map((command): string => command.name).join('\n'), true);
+      em.addField('Command List: ', commandNames.join('\n'));
       em.setFooter(`\nyou can send \`${process.env.PREFIX}help <command name>\` to get info on a specific command!`);
 
       await message.author

--- a/src/commands/pickreactor.ts
+++ b/src/commands/pickreactor.ts
@@ -1,17 +1,17 @@
 import Discord from 'discord.js';
 
 export default {
-  name: 'pickreacter',
+  name: 'pickreactor',
   description: "Pick a random user from a message's reactions",
-  aliases: [],
-  category: ['League'],
+  args: true,
+  category: 'fun',
   usage: ['pickreacter #channel messageID'],
   async execute(message: Discord.Message, args: string[]): Promise<void> {
     if (!message.member.hasPermission('MANAGE_MESSAGES')) {
       return;
     }
     if (args.length !== 2) {
-      message.reply('Error. Incorrect number of permissions supplied.');
+      message.reply('Error. Incorrect number of arguments supplied.');
       return;
     }
 

--- a/src/commands/poll.ts
+++ b/src/commands/poll.ts
@@ -7,7 +7,7 @@ export default {
   category: ['Fun'],
   usage: ['<poll question>, <poll answer 1>, <poll answer 2>, <poll answer 3>, <poll answer 4>'],
   async execute(message: Discord.Message): Promise<void> {
-    const args = message.content.slice(JSON.parse(<string>process.env.PREFIX).length).split(', ');
+    const args = message.content.slice((<string>process.env.PREFIX).length).split(', ');
 
     if (!args.length) {
       await message.channel.send('Poll set up incorrectly. use the help command to see how this works.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,12 +12,14 @@ dotenv();
 // Module augmentation to extend Discord.Client with "commands" property
 const client = new Discord.Client();
 client.commands = new Discord.Collection();
+client.commandNames = [];
 
 // Load command files
 const commandFiles = fs.readdirSync(path.resolve(__dirname, './commands')).filter((file: string): boolean => /(\.js|\.ts)/.test(file));
 commandFiles.forEach((file: string): void => {
   const command = require(path.resolve(__dirname, `./commands/${file}`)).default as Command;
   client.commands.set(command.name, command);
+  client.commandNames.push(command.name);
 
   // Clone additional commands in client.commands if the current command has aliases.
   if (command.aliases) {


### PR DESCRIPTION
 __1) Cleanup .help - has duplicates__
I think this bug had to do with the way I was making command aliases work. When `index.ts` loops through the filesystem to put each command in `client.command`, it also puts the aliases on the same level as the original command name. I dunno if that makes any sense.
Anyways, my current workaround for that is to create another variable on `client` called `commandNames` that just holds a string of each original command name (no aliases)

__2) Pickreactor - Does not respond to help command__
The bug for this had to do with `pickreactor.ts` having its alias property set as:
```js
aliases: [],
```
I removed that and it worked. Also I fixed the spelling error. It's pickreactor, not pickreacter...

__4) Poll command__
Once dotenv does its thing, the variables in process.env aren't JSON anymore (unless it's a string that's crazily formatted to still look like JSON, like with FIREBASE_CONFIG).  I got the poll command working by removing the `JSON.parse`